### PR TITLE
Deep merge fix

### DIFF
--- a/lib/puppet/functions/collections/deep_merge.rb
+++ b/lib/puppet/functions/collections/deep_merge.rb
@@ -34,7 +34,7 @@ Puppet::Functions.create_function(:'collections::deep_merge') do
     # Options are expected to be a hash with Symbol keys.
     options_with_syms = options.transform_keys(&:to_sym)
 
-    result = wrapped_dest.deep_merge(wrapped_source, options_with_syms)
+    result = wrapped_dest.deep_merge!(wrapped_source, options_with_syms)
 
     result[:data]
   end

--- a/spec/defines/file_spec.rb
+++ b/spec/defines/file_spec.rb
@@ -340,7 +340,7 @@ EOF
           owner: 'root',
           group: 'root',
           mode: '0644',
-          content: "---\nlist:\n- 1\n- 2\nhash:\n  one: 1\n  two: 2\nrepl:\n  not_two: 7\n"
+          content: "---\nlist:\n- 1\n- 2\nhash:\n  one: 3\n  two: 2\nrepl:\n  not_two: 2\n"
         )
 
         is_expected.to contain_collections__create('foo').with(

--- a/spec/defines/file_spec.rb
+++ b/spec/defines/file_spec.rb
@@ -40,8 +40,10 @@ describe 'collections::file' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
+      # Basic test - merge items in the right order.
       let(:pre_condition) do
         <<EOF
+
   collections::file { '/tmp/collections-file-test':
     collector => 'file-test',
     template  => 'collections/yaml.erb',
@@ -53,7 +55,9 @@ describe 'collections::file' do
     },
     data      => {
       list    => [ 1 ],
-      hash    => { one => 1 },
+      hash    => {
+        value => 'initialised to 1'
+      }
     },
   }
 
@@ -62,22 +66,24 @@ describe 'collections::file' do
     resource => 'collections::debug_executor'
   }
 
-  collections::append { 'Add two':
+  collections::append { 'Append to the list, overwrite the hash key':
     target => 'file-test',
     data   => {
       list => [ 2 ],
-      hash => { two => 2 },
-      repl => { not_two => 7 },
+      hash => {
+        value => 'overwritten to 2'
+      }
     },
   }
 
-  collections::append { 'Overwrite':
+  collections::append { 'Append to the list, overwrite the hash key again':
     target => 'file-test',
     data   => {
-      hash => { one => 3 },
-      repl => { not_two => 2 },
+      list => [ 3 ],
+      hash => {
+        value => 'finally set to 3'
+      }
     },
-    require => Collections::Append['Add two']
   }
 EOF
       end
@@ -101,34 +107,29 @@ EOF
               1,
             ],
             'hash' => {
-              'one' => 1,
+              'value' => 'initialised to 1',
             },
           }
         )
-        is_expected.to contain_collections__append('Add two').with(
-          name: 'Add two',
+        is_expected.to contain_collections__append('Append to the list, overwrite the hash key').with(
           target: 'file-test',
           data: {
             'list' => [
               2,
             ],
             'hash' => {
-              'two' => 2,
-            },
-            'repl' => {
-              'not_two' => 7,
+              'value' => 'overwritten to 2',
             },
           }
         )
-        is_expected.to contain_collections__append('Overwrite').with(
-          name: 'Overwrite',
+        is_expected.to contain_collections__append('Append to the list, overwrite the hash key again').with(
           target: 'file-test',
           data: {
+            'list' => [
+              3
+            ],
             'hash' => {
-              'one' => 3,
-            },
-            'repl' => {
-              'not_two' => 2,
+              'value' => 'finally set to 3',
             },
           }
         )
@@ -137,7 +138,6 @@ EOF
           defaults: {}
         )
         is_expected.to contain_collections__register_executor('collections::file::writer::file-test').with(
-          name: 'collections::file::writer::file-test',
           target: 'file-test',
           resource: 'collections::file::writer',
           parameters: {
@@ -158,57 +158,21 @@ EOF
           target: 'file-test',
           resource: 'collections::debug_executor'
         )
-        is_expected.to contain_collections__append('Add two').with(
-          target: 'file-test',
-          data: {
-            'list' => [
-              2,
-            ],
-            'hash' => {
-              'two' => 2,
-            },
-            'repl' => {
-              'not_two' => 7,
-            },
-          }
-        )
-        is_expected.to contain_collections__append('Overwrite').with(
-          target: 'file-test',
-          data: {
-            'hash' => {
-              'one' => 3,
-            },
-            'repl' => {
-              'not_two' => 2,
-            },
-          }
-        )
         is_expected.to contain_collections__iterator('file-test')
         is_expected.to contain_collections__commit('file-test').with(
           items: [
             {
               'list' => [1],
-              'hash' => { 'one' => 1 }
+              'hash' => { 'value' => 'initialised to 1' }
             },
             {
-              'list' => [
-                2,
-              ],
-              'hash' => {
-                'two' => 2,
-              },
-              'repl' => {
-                'not_two' => 7,
-              },
+              'list' => [2],
+              'hash' => { 'value' => 'overwritten to 2' }
             },
             {
-              'hash' => {
-                'one' => 3,
-              },
-              'repl' => {
-                'not_two' => 2,
-              },
-            },
+              'list' => [3],
+              'hash' => { 'value' => 'finally set to 3' }
+            }
           ],
           actions: [],
           executors: [
@@ -237,32 +201,17 @@ EOF
           target: 'file-test',
           items: [
             {
-              'list' => [
-                1,
-              ],
-              'hash' => {
-                'one' => 1
-              },
+              'list' => [1],
+              'hash' => { 'value' => 'initialised to 1' }
             },
             {
-              'list' => [
-                2,
-              ],
-              'hash' => {
-                'two' => 2,
-              },
-              'repl' => {
-                'not_two' => 7,
-              },
+              'list' => [2],
+              'hash' => { 'value' => 'overwritten to 2' }
             },
             {
-              'hash' => {
-                'one' => 3,
-              },
-              'repl' => {
-                'not_two' => 2,
-              },
-            },
+              'list' => [3],
+              'hash' => { 'value' => 'finally set to 3' }
+            }
           ],
           'file' => {
             'owner' => 'root',
@@ -277,32 +226,17 @@ EOF
           target: 'file-test',
           items: [
             {
-              'list' => [
-                1,
-              ],
-              'hash' => {
-                'one' => 1
-              },
+              'list' => [1],
+              'hash' => { 'value' => 'initialised to 1' }
             },
             {
-              'list' => [
-                2,
-              ],
-              'hash' => {
-                'two' => 2,
-              },
-              'repl' => {
-                'not_two' => 7,
-              },
+              'list' => [2],
+              'hash' => { 'value' => 'overwritten to 2' }
             },
             {
-              'hash' => {
-                'one' => 3,
-              },
-              'repl' => {
-                'not_two' => 2,
-              },
-            },
+              'list' => [3],
+              'hash' => { 'value' => 'finally set to 3' }
+            }
           ]
         )
         is_expected.to contain_notify('Collection file-test:').with(
@@ -310,27 +244,16 @@ EOF
             'items' => [
               {
                 'list' => [1],
-                'hash' => {
-                  'one' => 1,
-                },
+                'hash' => { 'value' => 'initialised to 1' }
               },
               {
                 'list' => [2],
-                'hash' => {
-                  'two' => 2,
-                },
-                'repl' => {
-                  'not_two' => 7,
-                },
+                'hash' => { 'value' => 'overwritten to 2' }
               },
               {
-                'hash' => {
-                  'one' => 3,
-                },
-                'repl' => {
-                  'not_two' => 2,
-                },
-              },
+                'list' => [3],
+                'hash' => { 'value' => 'finally set to 3' }
+              }
             ],
           }
         )
@@ -340,7 +263,7 @@ EOF
           owner: 'root',
           group: 'root',
           mode: '0644',
-          content: "---\nlist:\n- 1\n- 2\nhash:\n  one: 3\n  two: 2\nrepl:\n  not_two: 2\n"
+          content: "---\nlist:\n- 1\n- 2\n- 3\nhash:\n  value: finally set to 3\n"
         )
 
         is_expected.to contain_collections__create('foo').with(

--- a/spec/defines/file_spec.rb
+++ b/spec/defines/file_spec.rb
@@ -419,6 +419,33 @@ EOF
           )
         end
       end
+
+      context 'false can overwrite true' do
+        let(:pre_condition) do
+          %(
+            collections::file { '/tmp/boolean-test':
+              collector => 'boolean-test',
+              template  => 'collections/yaml.erb',
+              data      => {
+                enabled => true
+              }
+            }
+            collections::append { 'Disable the key':
+              target => 'boolean-test',
+              data   => {
+                enabled => false
+              }
+            }
+          )
+        end
+
+        basic_structure('boolean-test')
+        it 'Sets enabled to false' do
+          is_expected.to contain_file('/tmp/boolean-test').with(
+            content: "---\nenabled: false\n"
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The `deep_merge` gem has a longstanding issue where using the `deep_merge` method  will never replace a `true` value with `false`. The `deep_merge!` method does have the expected behaviour, and the code in this module already creates a duplicate object for the destination object, so the fix is simple.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
n/a