### PR TITLE
Add EPP support and `template_type` param

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ YAML:
 ```puppet
   collections::file { '/path/to/file.yaml':
     collector => 'app-config-file',
-    template  => 'collections/yaml.erb',
+    template  => 'collections/yaml.epp',
     file      => {
       owner => 'root',
       group => 'root',
@@ -140,7 +140,7 @@ You can then add data to the file using collections::append:
 ```
 
 #### Concat
-Template name: `collections/concat.erb`
+Template name: `collections/concat.epp` (or .erb)
 
 This allows for joining individual content blocks together, with some inbuilt
 ordering. It expects the `data` key to be a hash containing two items:
@@ -162,13 +162,13 @@ collections::append { 'Append to a concat file':
 ```
 
 #### YAML
-Template name: `collections/yaml.erb`
+Template name: `collections/yaml.epp` (or .erb)
 
 Takes any sequence of `data` items and sequentially merges them together with
 `deep_merge`, then converts the result to YAML and writes it to a file.
 
 #### JSON
-Template name: `collections/json.erb`
+Template name: `collections/json.epp` (or .erb)
 
 Takes any sequence of `data` items and sequentially merges them together with
 `deep_merge`, then converts the result to JSON and writes it to a file.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -170,22 +170,29 @@ of allowing portions of a file to be defined in many places. The file will
 be generate from a template, with data collated from any number of
 `collection::file::fragment` resources.
 
-The output of the collated resources will be a variable `$data` (or `@data`
-within erb templates). If you need, you can also access `@items`, which is
-the raw list of all items in the collection.
+EPP templates will receive two parameters:
+  * `Any $data` - The contents of all `data` parameters from the collection
+                  merged
+  * 'Array $items` - An array containing each `data` parameter from the
+                     collection, in order.
+
+ERB templates can access these two variables as `@data` and `@items`.
 
 As a convenience, a small set of templates are predefined within the
 collections module to suit a few use cases:
 
-#### `collections/concat.erb`
+#### `collections/concat.epp`
+(Also .erb)
 This template allows constructing a file from multiple content blocks, with
 ordering based upon an optional `order` key. Fragments should contain a
 `content` key. Order will default to 1000 if it is not supplied.
 
-#### `collections/yaml.erb`
+#### `collections/yaml.epp`
+(Also .erb)
 This template will output the collected data as a YAML document
 
-#### `collections/json.erb`
+#### `collections/json.epp`
+(Also .erb)
 This template will output the collected data as a JSON document
 
 #### Examples
@@ -197,7 +204,7 @@ This template will output the collected data as a JSON document
 
 collections::file { '/etc/motd':
   collector => 'motd',
-  template  => 'collections/concat.erb',
+  template  => 'collections/concat.epp',
   data      => {
     order   => 1,
     content => file('my-module/motd-header'),
@@ -220,7 +227,7 @@ collections::file::fragment { 'Add an unauthorised access warning':
 
 collections::file { '/etc/service/config.yaml':
   collector => 'service-config',
-  template  => 'collections/yaml.erb',
+  template  => 'collections/yaml.epp',
   file      => {
     owner   => 'root',
     group   => 'service',
@@ -243,6 +250,7 @@ The following parameters are available in the `collections::file` defined type:
 * [`collector`](#-collections--file--collector)
 * [`template`](#-collections--file--template)
 * [`template_body`](#-collections--file--template_body)
+* [`template_type`](#-collections--file--template_type)
 * [`data`](#-collections--file--data)
 * [`file`](#-collections--file--file)
 * [`merge_options`](#-collections--file--merge_options)
@@ -271,6 +279,15 @@ The template code to use (content of a template file, rather than a path).
 Either this or `template` (a path to a template in a module) must be passed.
 
 Default value: `undef`
+
+##### <a name="-collections--file--template_type"></a>`template_type`
+
+Data type: `Enum['epp','erb','auto']`
+
+The template language used. The default is `auto`, which will default to 'erb'
+unless a filename template is passed that ends in `.epp`.
+
+Default value: `'auto'`
 
 ##### <a name="-collections--file--data"></a>`data`
 

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -5,22 +5,29 @@
 # be generate from a template, with data collated from any number of
 # `collection::file::fragment` resources.
 #
-# The output of the collated resources will be a variable `$data` (or `@data`
-# within erb templates). If you need, you can also access `@items`, which is
-# the raw list of all items in the collection.
+# EPP templates will receive two parameters:
+#   * `Any $data` - The contents of all `data` parameters from the collection
+#                   merged
+#   * 'Array $items` - An array containing each `data` parameter from the
+#                      collection, in order.
+#
+# ERB templates can access these two variables as `@data` and `@items`.
 #
 # As a convenience, a small set of templates are predefined within the
 # collections module to suit a few use cases:
 #
-# #### `collections/concat.erb`
+# #### `collections/concat.epp`
+# (Also .erb)
 # This template allows constructing a file from multiple content blocks, with
 # ordering based upon an optional `order` key. Fragments should contain a
 # `content` key. Order will default to 1000 if it is not supplied.
 #
-# #### `collections/yaml.erb`
+# #### `collections/yaml.epp`
+# (Also .erb)
 # This template will output the collected data as a YAML document
 #
-# #### `collections/json.erb`
+# #### `collections/json.epp`
+# (Also .erb)
 # This template will output the collected data as a JSON document
 #
 # @example
@@ -28,7 +35,7 @@
 #
 #   collections::file { '/etc/motd':
 #     collector => 'motd',
-#     template  => 'collections/concat.erb',
+#     template  => 'collections/concat.epp',
 #     data      => {
 #       order   => 1,
 #       content => file('my-module/motd-header'),
@@ -51,7 +58,7 @@
 #
 #   collections::file { '/etc/service/config.yaml':
 #     collector => 'service-config',
-#     template  => 'collections/yaml.erb',
+#     template  => 'collections/yaml.epp',
 #     file      => {
 #       owner   => 'root',
 #       group   => 'service',
@@ -77,6 +84,10 @@
 #   The template code to use (content of a template file, rather than a path).
 #   Either this or `template` (a path to a template in a module) must be passed.
 #
+# @param [Enum['epp','erb','auto']] template_type
+#   The template language used. The default is `auto`, which will default to 'erb'
+#   unless a filename template is passed that ends in `.epp`.
+#
 # @param [Any] data
 #   Optional. Initial data for the collection.
 #   If provided, a `collection::append` resource named `<collectionname>::auto-initial-data` will
@@ -101,6 +112,7 @@ define collections::file (
 
   Optional[String[3]] $template = undef,
   Optional[String] $template_body = undef,
+  Enum['epp','erb','auto'] $template_type = 'auto',
   Any $data = undef,
   Hash[String,Variant[Boolean,String]] $merge_options = {},
 
@@ -150,6 +162,7 @@ define collections::file (
       file                => collections::deep_merge($file, $set_default_file_path),
       template            => $template,
       template_body       => $template_body,
+      template_type       => $template_type,
       merge_options       => $merge_options,
       reverse_merge_order => $reverse_merge_order,
     },

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -122,7 +122,7 @@ define collections::file (
   if $template == undef and $template_body == undef {
     fail("Exactly one of 'template' or 'template_body' must be passed to 'collections::file'")
   }
-  if $template != undef and $template_body != undef {
+  if $template and $template_body {
     fail("Exactly one of 'template' or 'template_body' must be passed to 'collections::file'")
   }
 
@@ -141,7 +141,7 @@ define collections::file (
     true
   }
 
-  if $data != undef {
+  if $data {
     $initial_items = [$data]
   } else {
     $initial_items = []

--- a/manifests/file/writer.pp
+++ b/manifests/file/writer.pp
@@ -68,23 +68,23 @@ define collections::file::writer (
 
   case $template_type {
     'auto': {
-      if $template != undef and $template =~ /(?i:\.epp)$/ {
+      if $template and $template =~ /(?i:\.epp)$/ {
         $content = epp($template, $epp_params)
-      } elsif $template != undef {
+      } elsif $template {
         $content = template($template)
       } else {
         $content = inline_template($template_body)
       }
     }
     'erb': {
-      if $template != undef {
+      if $template {
         $content = template($template)
       } else {
         $content = inline_template($template_body)
       }
     }
     'epp': {
-      if $template != undef {
+      if $template {
         $content = epp($template, $epp_params)
       } else {
         $content = inline_epp($template_body, $epp_params)

--- a/spec/defines/file_spec.rb
+++ b/spec/defines/file_spec.rb
@@ -32,7 +32,7 @@ describe 'collections::file' do
   let(:params) do
     {
       collector: 'foo',
-      template: 'collections/yaml.erb'
+      template: 'collections/yaml.epp'
     }
   end
 
@@ -46,7 +46,7 @@ describe 'collections::file' do
 
   collections::file { '/tmp/collections-file-test':
     collector => 'file-test',
-    template  => 'collections/yaml.erb',
+    template  => 'collections/yaml.epp',
     file      => {
       # options to be passed to the file resource
       owner   => root,
@@ -96,7 +96,7 @@ EOF
         is_expected.to contain_collections__file('/tmp/collections-file-test').with(
           name: '/tmp/collections-file-test',
           collector: 'file-test',
-          template: 'collections/yaml.erb',
+          template: 'collections/yaml.epp',
           file: {
             'owner' => 'root',
             'group' => 'root',
@@ -147,8 +147,9 @@ EOF
               'mode' => '0644',
               'path' => '/tmp/collections-file-test',
             },
-            'template' => 'collections/yaml.erb',
+            'template' => 'collections/yaml.epp',
             'template_body' => nil,
+            'template_type' => 'auto',
             'merge_options' => {},
             'reverse_merge_order' => false,
           }
@@ -189,8 +190,9 @@ EOF
                   'mode' => '0644',
                   'path' => '/tmp/collections-file-test',
                 },
-                'template' => 'collections/yaml.erb',
+                'template' => 'collections/yaml.epp',
                 'template_body' => nil,
+                'template_type' => 'auto',
                 'merge_options' => {},
                 'reverse_merge_order' => false,
               },
@@ -219,8 +221,9 @@ EOF
             'mode' => '0644',
             'path' => '/tmp/collections-file-test',
           },
-          'template' => 'collections/yaml.erb',
-          'template_body' => nil
+          'template' => 'collections/yaml.epp',
+          'template_body' => nil,
+          'template_type' => 'auto'
         )
         is_expected.to contain_collections__debug_executor('file-test::executor::1').with(
           target: 'file-test',
@@ -277,8 +280,9 @@ EOF
             'file' => {
               'path' => '/foo/bar',
             },
-            'template' => 'collections/yaml.erb',
+            'template' => 'collections/yaml.epp',
             'template_body' => nil,
+            'template_type' => 'auto',
             'merge_options' => {},
             'reverse_merge_order' => false,
           }
@@ -294,8 +298,9 @@ EOF
                 'file' => {
                   'path' => '/foo/bar',
                 },
-                'template' => 'collections/yaml.erb',
+                'template' => 'collections/yaml.epp',
                 'template_body' => nil,
+                'template_type' => 'auto',
                 'merge_options' => {},
                 'reverse_merge_order' => false,
               },
@@ -308,8 +313,9 @@ EOF
           'file' => {
             'path' => '/foo/bar',
           },
-          'template' => 'collections/yaml.erb',
+          'template' => 'collections/yaml.epp',
           'template_body' => nil,
+          'template_type' => 'auto',
           'merge_options' => {},
           'reverse_merge_order' => false
         )
@@ -325,7 +331,7 @@ EOF
           %(
             collections::file { '/tmp/yaml-test':
               collector     => 'yaml-test',
-              template      => 'collections/yaml.erb',
+              template      => 'collections/yaml.epp',
             }
             [ 3, 1, 4, 2 ].each |$num| {
               collections::append { "Add ${num}":
@@ -349,7 +355,7 @@ EOF
           %(
             collections::file { '/tmp/json-test':
               collector     => 'json-test',
-              template      => 'collections/json.erb',
+              template      => 'collections/json.epp',
             }
             [ 3, 1, 4, 2 ].each |$num| {
               collections::append { "Add ${num}":
@@ -373,7 +379,7 @@ EOF
           %(
             collections::file { '/tmp/concat-test':
               collector     => 'concat-test',
-              template      => 'collections/concat.erb',
+              template      => 'collections/concat.epp',
             }
             [ 3, 1, 4, 2 ].each |$num| {
               collections::append { "Add ${num}":
@@ -425,7 +431,7 @@ EOF
           %(
             collections::file { '/tmp/boolean-test':
               collector => 'boolean-test',
-              template  => 'collections/yaml.erb',
+              template  => 'collections/yaml.epp',
               data      => {
                 enabled => true
               }
@@ -443,6 +449,76 @@ EOF
         it 'Sets enabled to false' do
           is_expected.to contain_file('/tmp/boolean-test').with(
             content: "---\nenabled: false\n"
+          )
+        end
+      end
+
+      context 'template_type works' do
+        let(:pre_condition) do
+          %(
+            collections::file { '/tmp/type-test-auto-epp':
+              collector     => 'type-test-auto-epp',
+              template_type => 'auto',
+              template      => 'collections/yaml.epp',
+              data          => {
+                epp => true,
+              },
+            }
+
+            collections::file { '/tmp/type-test-auto-erb':
+              collector     => 'type-test-auto-erb',
+              template_type => 'auto',
+              template      => 'collections/yaml.erb',
+              data          => {
+                epp => false,
+              },
+            }
+
+            collections::file { '/tmp/type-test-erb-erb':
+              collector     => 'type-test-erb-erb',
+              template_type => 'auto',
+              template      => 'collections/yaml.erb',
+              data          => {
+                epp => false,
+              },
+            }
+
+            collections::file { '/tmp/type-test-epp-epp':
+              collector     => 'type-test-epp-epp',
+              template_type => 'auto',
+              template      => 'collections/yaml.epp',
+              data          => {
+                epp => true,
+              },
+            }
+          )
+        end
+
+        basic_structure('type-test-auto-epp')
+        it 'Renders epp as epp (auto)' do
+          is_expected.to contain_file('/tmp/type-test-auto-epp').with(
+            content: "---\nepp: true\n"
+          )
+        end
+
+        basic_structure('type-test-auto-erb')
+        it 'Renders erb as erb (auto)' do
+          is_expected.to contain_file('/tmp/type-test-auto-erb').with(
+            content: "---\nepp: false\n"
+          )
+        end
+
+        basic_structure('type-test-epp-epp')
+        it 'Renders epp as epp' do
+          is_expected.to contain_file('/tmp/type-test-epp-epp').with(
+            content: "---\nepp: true\n"
+          )
+        end
+
+        basic_structure('type-test-erb-erb')
+        it 'Renders erb as erb' do
+          is_expected.to contain_file('/tmp/type-test-erb-erb').with(
+            content: "---\nepp: false\n"
           )
         end
       end

--- a/templates/concat.epp
+++ b/templates/concat.epp
@@ -1,0 +1,26 @@
+<%- | Array $items,
+      Any $data
+| -%>
+<%-
+  # Sort the fragments by a provided 'order' key and by their definition order
+  $fragments = $items.map |$index, $fragment| {
+    [ $fragment, [get($fragment,'order',1000), $index] ]
+  }.sort |$a, $b| {
+    $a_order = $a[1][0]
+    $a_index = $a[1][1]
+    $b_order = $b[1][0]
+    $b_index = $b[1][1]
+
+    $order_sort = compare($a_order, $b_order)
+    if $order_sort == 0 {
+      compare($a_index, $b_index)
+    } else {
+      $order_sort
+    }
+  }.map |$fragment| {
+    $fragment[0]['content']
+  }
+-%>
+<%=
+  join($fragments, "\n")
+%>

--- a/templates/json.epp
+++ b/templates/json.epp
@@ -1,0 +1,4 @@
+<%- | Any $data, Array $items | -%>
+<%=
+  stdlib::to_json($data)
+%>

--- a/templates/yaml.epp
+++ b/templates/yaml.epp
@@ -1,0 +1,4 @@
+<%- | Any $data, Array $items | -%>
+<%=
+  stdlib::to_yaml($data)
+-%>


### PR DESCRIPTION
template_type defaults to 'auto', which will default to erb unless you pass in a template path that ends in .epp

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add EPP support
Add EPP versions of the included templates
Add template_type parameter to `collections::file`

#### This Pull Request (PR) fixes the following issues
n/a